### PR TITLE
Fix URL to Demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ The Zalando SE public API was created to give a programmatic access to Zalando w
 * [API Documentation](https://github.com/zalando/shop-api-documentation/wiki) (Wiki).
 * [API Endpoint Reference](https://api.zalando.com/swagger/index.html) (Explore the API using Swagger)
 * [API Schema](https://api.zalando.com/schema/swagger.json) (Parse json file)
-* [Demo App](https://github.com/zalando/shop-api-demo/) (See our API in action)
+* [Demo App](https://github.com/zalando-incubator/shop-api-demo/) (See our API in action)
 * [Public Google Group](https://groups.google.com/forum/#!forum/zalando-api) (Get the latest news and changes)
 


### PR DESCRIPTION
Demo app is under `zalando-incubator` account.

Please update Wiki too:
- [ ] Footer
```
[Demo App](https://github.com/zalando-incubator/shop-api-demo/)
```

- [ ] API Introduction
```
Demo WebApp: [see it in action](http://zalando-incubator.github.io/shop-api-demo/)

[Demo source on GitHub](https://github.com/zalando-incubator/shop-api-demo/)
```